### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 
 This project contains a Multi-Channel Platform (MCP) server used to create an assistant integrated with n8n. The assistant can be used to search for n8n documentation, example workflows, and community forums.
 
+<a href="https://glama.ai/mcp/servers/@onurpolat05/n8n-Assistant">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@onurpolat05/n8n-Assistant/badge" alt="n8n-asistans MCP server" />
+</a>
+
 ## Features
 
 - **Web Search**: Searches n8n documentation, workflows, and community forums based on a specific query.


### PR DESCRIPTION
This PR adds a badge for the [n8n-asistans](https://glama.ai/mcp/servers/@onurpolat05/n8n-Assistant) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@onurpolat05/n8n-Assistant">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@onurpolat05/n8n-Assistant/badge" alt="n8n-asistans MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.